### PR TITLE
Implement meetup GET single meetup route

### DIFF
--- a/server/tests/meetups-test.js
+++ b/server/tests/meetups-test.js
@@ -19,6 +19,16 @@ const testMeetup = () => {
           done();
         });
     });
+    
+    it('GET /meetups/:id should return a single meetup record', (done) => {
+      chai.request(app)
+        .get('/api/v1/meetups/1')
+        .end((err, res) => {
+          res.should.have.status(200);
+          res.body.data.should.be.a('object');
+          done();
+        });
+    });
   });
 }
 

--- a/server/v1/Controllers/MeetupController.js
+++ b/server/v1/Controllers/MeetupController.js
@@ -31,6 +31,22 @@ class MeetupController {
       data,
     });
   }
+
+  /**
+   * Retrieve a single resource from the table
+   * @param {Object} req - request made
+   * @param {Object} res - response to be given
+   * @returns {Object} - response
+   */
+  static retrieve(req, res) {
+    const id = parseInt(req.params.id, 10);
+    const resource = Meetup.getOne(id);
+    res.status(200).send({
+      status: 200,
+      data: resource,
+    });
+  }
+
 }
 
 export default MeetupController;

--- a/server/v1/Controllers/MeetupController.js
+++ b/server/v1/Controllers/MeetupController.js
@@ -31,6 +31,21 @@ class MeetupController {
       data,
     });
   }
+
+  /**
+   * Retrieve a single resource from the table
+   * @param {Object} req - request made
+   * @param {Object} res - response to be given
+   * @returns {Object} - response
+   */
+  static retrieve(req, res) {
+    const id = parseInt(req.params.id, 10);
+    const resource = Meetup.getOne(id);
+    res.status(200).send({
+      status: 200,
+      data: resource,
+    });
+  }
 }
 
 export default MeetupController;

--- a/server/v1/routes/meetups.js
+++ b/server/v1/routes/meetups.js
@@ -4,5 +4,6 @@ import MeetupController from '../Controllers/MeetupController';
 const meetupRouter = Router();
 
 meetupRouter.get('/', MeetupController.list);
+meetupRouter.get('/:id', MeetupController.retrieve);
 
 export default meetupRouter;


### PR DESCRIPTION
#### What does this PR do?
- setup GET '/meetups/:id' route to get single meetup
#### Description of Task to be completed?
- Write endpoint test
- Add route to meetup router
- Write controller function to handle route
#### How should this be manually tested?
- Clone repository
- On terminal run "npm install" then "npm run start"
- On Postman, test route "https://localhost:8080/v1/api/meetups/1"
- This should return a status of 200 and the requested meetup
#### What are the relevant pivotal tracker stories?
- https://www.pivotaltracker.com/story/show/162860174